### PR TITLE
Add full-screen container patch

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,9 @@ HTML("""
 <style>
 .text_cell.unrendered {
   background-color: yellow;
+}
+.container {
+  width: 100% !important
 } 
 </style>
 """)


### PR DESCRIPTION
Added in the patch from the session last week. After firing up Jupyter without it I lasted...about three seconds before I was hunting up that style patch.